### PR TITLE
Add EF Core relational package dependency

### DIFF
--- a/src/BranchManager.Api/BranchManager.Api.csproj
+++ b/src/BranchManager.Api/BranchManager.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add Microsoft.EntityFrameworkCore.Relational to enable relational mapping extensions used by the DbContext

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3b97d78588322847bcb6dc058358f